### PR TITLE
Add SetNotSolid detour

### DIFF
--- a/lua/autorun/server/sv_acf_balance_detours.lua
+++ b/lua/autorun/server/sv_acf_balance_detours.lua
@@ -1,10 +1,19 @@
+local istable = istable
 local entMeta = FindMetaTable( "Entity" )
 
 entMeta.o_SetNotSolid = entMeta.o_SetNotSolid or entMeta.SetNotSolid
 function entMeta:SetNotSolid( solid )
-    if solid and self:IsVehicle() then
-        return
+    if not self:IsVehicle() or solid then
+        return self:o_SetNotSolid( solid )
     end
 
-    self:o_SetNotSolid( solid )
+    -- Only affect wire pod linked seats
+    local entTable = self:GetTable()
+    if not istable( entTable.OnDieFunctions ) then
+        return self:o_SetNotSolid( solid )
+    end
+
+    if not entTable.OnDieFunctions.wire_pod_remove then
+        return self:o_SetNotSolid( solid )
+    end
 end

--- a/lua/autorun/server/sv_acf_balance_detours.lua
+++ b/lua/autorun/server/sv_acf_balance_detours.lua
@@ -1,0 +1,10 @@
+local entMeta = FindMetaTable( "Entity" )
+
+entMeta.o_SetNotSolid = entMeta.o_SetNotSolid or entMeta.SetNotSolid
+function entMeta:SetNotSolid( solid )
+    if solid and self:IsVehicle() then
+        return
+    end
+
+    self:o_SetNotSolid( solid )
+end


### PR DESCRIPTION
Players can use E2 and SF SetNotSolid on seats and thus be unhittable by acf in their chair